### PR TITLE
Muokkaa eristäytyneisyyden määritelmää

### DIFF
--- a/index.html
+++ b/index.html
@@ -5807,7 +5807,7 @@ CREATE TABLE Kirjanpitotapahtuma
       <li>Atomisuudella (<code>Atomicity</code>) varmistetaan, että tietokantatransaktio suoritetaan joko kokonaisuudessaan tai ei lainkaan. Jos tietokannanhallintajärjestelmään tehtävät transaktiot eivät olisi atomisia, voisi esimerkiksi päivityskyselyistä päätyä tietokantaan asti vain osa -- tilisiirtoesimerkissä vain rahan ottaminen yhdeltä tililtä, mutta ei sen lisäämistä toiselle.</li>
       
       <li>Eheydellä (<code>Consistency</code>) varmistetaan, että tietokantaan määritellyt rajoitteet, kuten viiteavaimet, pätevät jokaisen transaktion jälkeen. Jos tietokanta ei mahdollistaisi eheystarkistusta, voisi esimerkiksi kirjanpito olla virheellinen.</li>
-      <li>Eristäytyneisyydellä (<code>Isolation</code>) varmistetaan, että transaktio ei voi lukea toisen tietoa toisesta transaktiosta ennenkuin toinen transaktio on suoritettu loppuun. Tällä varmistetaan se, että jos transaktioita suoritetaan rinnakkaisesti, kumpikin näkee tietokannan eheässä tilassa.</li>
+      <li>Eristäytyneisyydellä (<code>Isolation</code>) varmistetaan, että transaktio (A) ei voi lukea toisen transaktion (B) muokkaamaa tietoa ennenkuin toinen transaktio (B) on suoritettu loppuun. Tällä varmistetaan se, että jos transaktioita suoritetaan rinnakkaisesti, kumpikin näkee tietokannan eheässä tilassa.</li>
 
       <li>Pysyvyydellä (<code>Durability</code>) varmistetaan, että transaktion suorituksessa tapahtuvat muutokset ovat pysyviä. Kun käyttäjä lisää tietoa tietokantaan, tietokannanhallintajärjestelmän tulee varmistaa että tieto säilyy myös virhetilanteissa (jos transaktion suoritus onnistuu).</li> 
 


### PR DESCRIPTION
Lause _"lukea toisen tietoa toisesta transaktiosta"_ tuntui melko vaikealta ymmärtää. Tämä muutos kenties selkiyttää? Liittyy issueen #15 parantaen hieman materiaalin transaktio-osuutta.